### PR TITLE
Breaking: fix 'clientSideFilters' argument typo.

### DIFF
--- a/lib/src/firestore_helpers.dart
+++ b/lib/src/firestore_helpers.dart
@@ -80,13 +80,13 @@ typedef ItemComparer<T> = int Function(T item1, T item2);
 Stream<List<T>> getDataFromQuery<T>({
   Query query,
   DocumentMapper<T> mapper,
-  List<ItemFilter<T>> clientSitefilters,
+  List<ItemFilter<T>> clientSideFilters,
   ItemComparer<T> orderComparer,
 }) {
   return query.snapshots().map((snapShot) {
     Iterable<T> items = snapShot.documents.map(mapper);
-    if (clientSitefilters != null) {
-      for (var filter in clientSitefilters) {
+    if (clientSideFilters != null) {
+      for (var filter in clientSideFilters) {
         items = items.where(filter);
       }
     }


### PR DESCRIPTION
I fixed a small typo: `clientSitefilters` becomes `clientSideFilters`.

Since this is a change in the optional arguments, this change would break current implementations that use the old argument.

If you merge it, make sure your users know about this change (and perhaps bump the version number by +1.0.0 in accordance to [semantic versioning](https://semver.org/)).

**EDIT: As of now I've only changed the lib's argument name, but not the README or everywhere else it's used. I'll do so later today (if you're haven't done it by then already at least ;) ).**