### PR TITLE
Fix clientSideFilters type issue

### DIFF
--- a/lib/src/geo_helpers.dart
+++ b/lib/src/geo_helpers.dart
@@ -249,6 +249,13 @@ Stream<List<T>> getDataInArea<T>(
 
   var query = buildQuery(
       collection: collection, constraints: getLocationsConstraint(locationFieldNameInDB, area));
+
+  if (clientSitefilters != null) {
+    clientSitefilters..insert(0, (item) => item != null);
+  } else {
+    clientSitefilters = [(item) => item != null];
+  }
+
   return getDataFromQuery<T>(
       query: query,
       mapper: (docSnapshot) {
@@ -272,7 +279,7 @@ Stream<List<T>> getDataInArea<T>(
         }
           return item;
       },
-      clientSitefilters: clientSitefilters != null ? ()=>clientSitefilters..insert(0,(item) => item != null) : [(item) => item != null],
+      clientSitefilters: clientSitefilters,
       orderComparer:
           distanceAccessor != null // i this case we don't have to calculate the distance again
               ? (item1, item2) => sortDecending


### PR DESCRIPTION
Fix for https://github.com/fluttercommunity/firestore_helpers/issues/11
Insert method on the List class returns void, so even `()=>clientSitefilters..insert(0,(item)` won't return an instance of list that we want to pass to the `clientSitefilters` of `getDataFromQuery` method.